### PR TITLE
feat(User Management)：allow administrators to activate accounts in the admin interface，163 Email Settings 

### DIFF
--- a/src/main/java/cn/edu/xjtlu/readingnotes/email/AccountEmailSender.java
+++ b/src/main/java/cn/edu/xjtlu/readingnotes/email/AccountEmailSender.java
@@ -1,40 +1,56 @@
 package cn.edu.xjtlu.readingnotes.email;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 import jakarta.mail.internet.MimeMessage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.MailException;
+
 @Component
 public class AccountEmailSender {
+    private static final Logger logger = LoggerFactory.getLogger(AccountEmailSender.class);
+    
+    // Move the configuration injection to the class scope
+    @Value("${spring.mail.username}")
+    private String fromEmail;
 
     @Autowired
     private JavaMailSender mailSender;
 
-    public void send(String to, String subject, String tpl, Object... args)
+    public void send(String to, String subject, String tpl, Object... args) 
             throws Exception {
         MimeMessage message = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
         Object[] plainArgs = new Object[args.length];
         for (int i = 0; i < args.length; i++) {
             if (args[i] instanceof String) {
-                plainArgs[i] = ((String) args[i])
-                    .replaceAll("</?.*?>", "");
+                // XSS protection: Filter HTML tags in email parameters
+                plainArgs[i] = ((String) args[i]).replaceAll("</?.*?>", "");
             } else {
                 plainArgs[i] = args[i];
             }
         }
         try {
-            helper.setFrom("your@smtp.mail.com");
+            helper.setFrom(fromEmail);  // Use class member variables
             helper.setTo(to);
             helper.setSubject(subject);
             helper.setText(
                 String.format(tpl, plainArgs),
                 String.format(tpl, args));
             mailSender.send(helper.getMimeMessage());
-        } catch (Exception e) {
+        } 
+        catch (MailException ex) {
+            logger.error("e-mail sending failed: {}", ex.getMessage());
+            throw ex;
+        }
+        catch (Exception e) {
+            logger.error("An unexpected error occurred: {}", e.getMessage());
             throw e;
         }
     }

--- a/src/main/java/cn/edu/xjtlu/readingnotes/user/controller/AdminController.java
+++ b/src/main/java/cn/edu/xjtlu/readingnotes/user/controller/AdminController.java
@@ -44,6 +44,14 @@ public class AdminController {
         return ResponseEntity.ok(userRepo.save(user));
     }
 
+    @PutMapping("/user/{id}/activate")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> activateUser(@PathVariable Long id) {
+        User user = userRepo.findById(id).orElseThrow();
+        user.setIsEnabled(true); 
+        return ResponseEntity.ok(userRepo.save(user));
+    }
+
     @DeleteMapping("/user/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public void deleteUser(@PathVariable Long id) {

--- a/src/main/java/cn/edu/xjtlu/readingnotes/user/controller/UserController.java
+++ b/src/main/java/cn/edu/xjtlu/readingnotes/user/controller/UserController.java
@@ -84,4 +84,4 @@ public class UserController {
         userRepo.save(existing);
         return new ResponseEntity<>(headers, HttpStatus.SEE_OTHER);
     } 
-}  
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,17 +15,16 @@ spring.thymeleaf.cache=false
 spring.thymeleaf.servlet.content-type=text/html; charset=utf-8
 spring.servlet.multipart.max-file-size=200KB
 spring.servlet.multipart.max-request-size=200KB
-spring.mail.host=your.email.smtp.server.com
-# your email smtp server port, typically 25, 465, or 587
+# Mail server configuration (163 Mailbox)
+spring.mail.host=smtp.163.com
 spring.mail.port=465
-spring.mail.username=your@email.com
-spring.mail.password=your-email-smtp-oauth2-access-code
+spring.mail.username=ReadingNotes_G41@163.com
+spring.mail.password=Cpt202Group41
 spring.mail.protocol=smtp
-spring.mail.properties.mail.default-encoding=UTF-8
 spring.mail.properties.mail.smtp.ssl.enable=true
-spring.mail.properties.mail.smtp.ssl.socketFactory.class=com.sun.mail.util.MailSSLSocketFactory
-spring.mail.properties.mail.smtp.ssl.socketFactory.fallback=false
 spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.auth.mechanisms=XOAUTH2
-spring.mail.properties.mail.smtp.starttls.enable=true
-spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.starttls.enable=false
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.timeout=10000
+spring.mail.properties.mail.smtp.writetimeout=15000
+# Remove incompatible OAuth2 authentication configurations

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -8,40 +8,48 @@
         <div class="mb-5">
             <h3>User Management</h3>
             <table class="table">
+                
                 <thead>
                     <tr>
                         <th>Username</th>
                         <th>Role</th>
-                        <th>Status</th>
+                        <th>Activated</th>  
+                        <th>Lock Status</th>
                         <th>Actions</th>
                     </tr>
                 </thead>
-                <tbody>
-                    <tr th:each="user : ${users}">
-                        <td th:text="${user.username}"></td>
-                        <td th:text="${user.role}"></td>
+                
+                <tr th:each="user : ${users}">
+                    <td th:text="${user.username}"></td>
+                    <td th:text="${user.role}"></td>
+                    <td>
+                        <span th:text="${user.enabled} ? 'Yes' : 'No'" 
+                              th:class="${user.enabled} ? 'text-success' : 'text-danger'"></span>
+                    </td>
+                    <td th:text="${user.nonLocked} ? 'Active' : 'Blocked'"></td>
+                    <td>
+                        <!-- Newly added activation button -->
+                        <a th:href="@{'/admin/user/' + ${user.id} + '/activate'}"
+                           class="btn btn-sm btn-info me-2" 
+                           th:if="${not user.enabled}">Activate</a>
                         
-                        <td th:text="${user.active} ? 'Active' : 'Blocked'"></td>
-                        <td>
-                            <span th:text="${user.active} ? 'Active' : 'Blocked'" 
-                                  th:class="${user.active} ? 'text-success' : 'text-danger'">
-                            </span>
-                        </td>
-                        <td>
-                            <a th:href="@{'/admin/user/' + ${user.id} + '/status?active=false'}"
-                               class="btn btn-sm btn-warning" th:if="${user.active}">Block</a>
-                            <a th:href="@{'/admin/user/' + ${user.id} + '/status?active=true'}"
-                               class="btn btn-sm btn-success" th:unless="${user.active}">Unblock</a>
-                            <form th:action="@{'/admin/user/' + ${user.id}}" method="post"
-                                  class="d-inline">
-                                <input type="hidden" name="_method" value="delete">
-                                <button type="submit" class="btn btn-sm btn-danger">
-                                    Delete
-                                </button>
-                            </form>
-                        </td>
-                    </tr>
-                </tbody>
+                        <!-- The original lock status button remains unchanged -->
+                        <a th:href="@{'/admin/user/' + ${user.id} + '/status?active=false'}"
+                           class="btn btn-sm btn-warning" 
+                           th:if="${user.nonLocked}">Block</a>
+                        <a th:href="@{'/admin/user/' + ${user.id} + '/status?active=true'}"
+                           class="btn btn-sm btn-success" 
+                           th:unless="${user.nonLocked}">Unblock</a>
+                        
+                        <form th:action="@{'/admin/user/' + ${user.id}}" method="post"
+                              class="d-inline">
+                            <input type="hidden" name="_method" value="delete">
+                            <button type="submit" class="btn btn-sm btn-danger ms-2">
+                                Delete
+                            </button>
+                        </form>
+                    </td>
+                </tr>
             </table>
         </div>
     </main>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -7,6 +7,10 @@
         <div th:if="${param.registered}" class="alert alert-success mt-3">
             Registration successful! Please login.
         </div>
+        <div th:if="${param.unactivated}" class="alert alert-warning">
+            The account is not activated. Please check your email
+            <a th:href="@{/resend-verification?email=${param.email}}">Resend the activation email</a>
+        </div>
         <form th:action="@{/login}" method="post" class="col-md-6">
             <div class="mb-3">
                 <input type="text" class="form-control" name="username" 


### PR DESCRIPTION
1. A user activation function has been added to the user management module, allowing administrators to manually activate unactivated user accounts. 2. The configuration of the email server has been optimized. 163 Mailbox is now used as the default email service, and unnecessary OAuth2 configurations have been removed. 3. On the login page, a prompt message for unactivated accounts has been added, and a link to resend the activation email has been provided.